### PR TITLE
Added feature to xp currency sub menu for Classic/Era version

### DIFF
--- a/Classic/modules/currency.lua
+++ b/Classic/modules/currency.lua
@@ -314,10 +314,17 @@ function CurrencyModule:ShowTooltip()
         if self.event == PLAYER_XP_UPDATE then
             local newXp = UnitXP('player')
             local xpGained = newXp - oldXp
+            if self.event == PLAYER_LEVEL_UP then
+                return -- There is a behavior where leveling up will show previous max xp and give a negative number.
+            end
             if xpGained > 1 then
-                self.killsRemaining = maxXp / xpGained
+                self.killsRemaining = (maxXp - curXp) / xpGained
                 GameTooltip:AddDoubleLine(L['Kills to level'] .. ':',
-                    string.format('%d', (self.killsRemaining)), r, g, b, 1, 1, 1)
+                    string.format('%d', self.killsRemaining), r, g, b, 1, 1, 1
+                )
+                GameTooltip:AddDoubleLine(L['Last xp gain'] .. ':',
+                    string.format('%d', xpGained), r, g, b, 1, 1,
+                    1)
                 self.oldXp = curXp
             end
         end

--- a/Classic/modules/currency.lua
+++ b/Classic/modules/currency.lua
@@ -17,12 +17,12 @@ function CurrencyModule:GetName()
 end
 
 function CurrencyModule:OnInitialize()
-    self.rerollItems = {697, -- Elder Charm of Good Fortune
-    752, -- Mogu Rune of Fate
-    776, -- Warforged Seal
-    994, -- Seal of Tempered Fate
-    1129, -- Seal of Inevitable Fate
-    1273 -- Seal of Broken Fate
+    self.rerollItems = { 697, -- Elder Charm of Good Fortune
+        752,                  -- Mogu Rune of Fate
+        776,                  -- Warforged Seal
+        994,                  -- Seal of Tempered Fate
+        1129,                 -- Seal of Inevitable Fate
+        1273                  -- Seal of Broken Fate
     }
 
     self.intToOpt = {
@@ -210,7 +210,6 @@ function CurrencyModule:CreateFrames()
 end
 
 function CurrencyModule:RegisterFrameEvents()
-
     for i = 1, 3 do
         self.curButtons[i]:EnableMouse(true)
         self.curButtons[i]:RegisterForClicks("AnyUp")
@@ -307,6 +306,7 @@ function CurrencyModule:ShowTooltip()
 
         local curXp = UnitXP('player')
         local maxXp = UnitXPMax('player')
+        local killsRemaining = ""
         local rested = GetXPExhaustion()
         -- XP
         GameTooltip:AddDoubleLine(XP .. ':',
@@ -314,10 +314,15 @@ function CurrencyModule:ShowTooltip()
         -- Remaining
         GameTooltip:AddDoubleLine(L['Remaining'] .. ':',
             string.format('%d (%d%%)', (maxXp - curXp), floor(((maxXp - curXp) / maxXp) * 100)), r, g, b, 1, 1, 1)
+        -- Kills remaining
+        if event == "PLAYER_XP_UPDATE" then
+            GameTooltip:AddDoubleLine(L['Kills to level'] .. ':',
+                string.format('%d', (killsRemaining)), r, g, b, 1, 1, 1)
+        end
         -- Rested
         if rested then
             GameTooltip:AddDoubleLine(L['Rested'] .. ':',
-                string.format('+%d (%d%%)', rested, floor((rested / maxXp) * 100)), r, g, b, 1, 1, 1)
+                string.format('%d', rested, floor((rested / maxXp) * 100)), r, g, b, 1, 1, 1)
         end
     else
         GameTooltip:AddLine("|cFFFFFFFF[|r" .. CURRENCY .. "|cFFFFFFFF]|r", r, g, b)

--- a/Classic/modules/currency.lua
+++ b/Classic/modules/currency.lua
@@ -314,19 +314,21 @@ function CurrencyModule:ShowTooltip()
         if self.event == PLAYER_XP_UPDATE then
             local newXp = UnitXP('player')
             local xpGained = newXp - oldXp
+            local lastXp = 0
             if self.event == PLAYER_LEVEL_UP then
-                return -- There is a behavior where leveling up will show previous max xp and give a negative number.
+                return -- There is a behavior where leveling up will show previous max xp and give a negative number. Unsure how to resolve.
             end
             if xpGained > 1 then
                 self.killsRemaining = (maxXp - curXp) / xpGained
-                GameTooltip:AddDoubleLine(L['Kills to level'] .. ':',
-                    string.format('%d', self.killsRemaining), r, g, b, 1, 1, 1
-                )
-                GameTooltip:AddDoubleLine(L['Last xp gain'] .. ':',
-                    string.format('%d', xpGained), r, g, b, 1, 1,
-                    1)
-                self.oldXp = curXp
+                self.lastXp = newXp - oldXp
             end
+            GameTooltip:AddDoubleLine(L['Kills to level'] .. ':',
+                string.format('%d', self.killsRemaining), r, g, b, 1, 1, 1
+            )
+            GameTooltip:AddDoubleLine(L['Last xp gain'] .. ':',
+                string.format('%d', self.lastXp), r, g, b, 1, 1,
+                1)
+            oldXp = UnitXP('player')
         end
 
         -- Rested

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -164,6 +164,7 @@ L['Enable Loadout Switcher'] = true;
 L['Talent Minimum Width'] = true;
 L['Open Artifact'] = true;
 L['Remaining'] = true;
+L['Kills to level'] = true;
 L['Available Ranks'] = true;
 L['Artifact Knowledge'] = true;
 
@@ -174,9 +175,11 @@ L['Only show current season'] = true;
 L["Mythic+ Teleports"] = true;
 L['Show Mythic+ Teleports'] = true;
 L['Use Random Hearthstone'] = true;
-L['Empty Hearthstones List'] = "If you see an empty list, /reload your UI a few seconds after the initial loading (Blizzard is loading items informations asynchronously so that's the only solution for now)."
+L['Empty Hearthstones List'] =
+"If you see an empty list, /reload your UI a few seconds after the initial loading (Blizzard is loading items informations asynchronously so that's the only solution for now)."
 L['Hearthstones Select'] = true;
-L['Hearthstones Select Desc'] = "Select which hearthstones to use (be careful if you select multiple hearthstones, you might want to check the 'Hearthstones Select' option)";
+L['Hearthstones Select Desc'] =
+"Select which hearthstones to use (be careful if you select multiple hearthstones, you might want to check the 'Hearthstones Select' option)";
 
 L["Classic"] = true;
 L["Burning Crusade"] = true;

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -165,6 +165,7 @@ L['Talent Minimum Width'] = true;
 L['Open Artifact'] = true;
 L['Remaining'] = true;
 L['Kills to level'] = true;
+L['Last xp gain'] = true;
 L['Available Ranks'] = true;
 L['Artifact Knowledge'] = true;
 


### PR DESCRIPTION
Edit2: Ready to merge and bug free

Edit - will investigate, but my addition to the addon seems to suffer due to the way updating works. The xp gained is being added over all the time inbetween the user deciding to mouse over - so if you kill 10 mobs and then mouse over, it will record the total of all 10 mobs being killed as your last "xp" gained. 


Hello! The submenu within the currency module will now display the number of kills remaining before a level up will occur, and this is based off the last xp blob that has been gained. So a quest will count as a kill in this section. 

One thing to note is that maxXp will be based on the character's previous known max, so a level up will look like negative experience and display a negative number until you gain experience once you have achieved a new level. 


![image](https://github.com/user-attachments/assets/0f6f198a-eb2a-4b8a-bd6b-4bdf379dd268)
