### PR TITLE
Feature: Tome Of Teleportation Integration

### DIFF
--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -195,6 +195,13 @@ L['Empty Hearthstones List'] = "If you see '" .. retrievingData .. "' in the lis
 L['Hearthstones Select'] = true;
 L['Hearthstones Select Desc'] = "Select which hearthstones to use (be careful if you select multiple hearthstones, you might want to check the 'Hearthstones Select' option)";
 
+-- Tome Of Teleportation
+L['Tome Of Teleportation'] = true;
+L['Tome Of Teleportation Integration'] = true;
+L['Enable Tome Of Teleportation'] = true;
+L['Tome Of Teleportation Desc'] = "When enabled, right-clicking the hearthstone will open Tome Of Teleportation instead of the default port menu. The port options button will be hidden.";
+L['Open Tome Of Teleportation'] = true;
+
 L["Classic"] = true;
 L["Burning Crusade"] = true;
 L["Wrath of the Lich King"] = true;


### PR DESCRIPTION
Added a new toggle option in the Travel module settings that allows users to integrate with the [Tome Of Teleportation](https://www.curseforge.com/wow/addons/tome-of-teleportation) addon.

**When enabled:**
- Right-clicking the hearthstone executes `/tele` command (opens Tome Of Teleportation menu)
- Left-clicking the hearthstone continues to work normally
- Port options button is hidden
- M+ Teleports button is hidden
- Tooltip shows simplified view with hearthstone cooldown and "Right-Click: Open Tome Of Teleportation"

**When disabled:**
- Original behavior is fully restored


<img width="916" height="719" alt="image" src="https://github.com/user-attachments/assets/da5bcd40-e725-4dcc-80d4-217a3266105f" />

